### PR TITLE
fix: add 0 to 1-digit days and months to fix statistics sorting

### DIFF
--- a/src/components/statistics-container/statistics-container.ts
+++ b/src/components/statistics-container/statistics-container.ts
@@ -123,10 +123,10 @@ class StatisticsContainer extends Component {
       .filter((userWord: UserWord) => userWord.optional.dateNew > 0)
       .map((userWord: UserWord) => {
         const date = new Date(userWord.optional.dateNew);
-        const year = date.getFullYear();
-        const month = date.getMonth(); // 0-11
-        const day = date.getDate();// 1-31;
-        return `${year}-${month + 1}-${day}`;
+        const year = `${date.getFullYear()}`;
+        const month = (`0${date.getMonth() + 1}`).slice(-2); // 0-11 + 1;
+        const day = (`0${date.getDate()}`).slice(-2);// 1-31;
+        return `${year}-${month}-${day}`;
       })
       .reduce((acc: { [index: string]: number }, el: string) => {
         acc[el] = (acc[el] || 0) + 1;
@@ -166,10 +166,10 @@ class StatisticsContainer extends Component {
       .filter((userWord: UserWord) => userWord.optional.dateEasy > 0)
       .map((userWord: UserWord) => {
         const date = new Date(userWord.optional.dateEasy);
-        const year = date.getFullYear();
-        const month = date.getMonth(); // 0-11
-        const day = date.getDate();// 1-31;
-        return `${year}-${month + 1}-${day}`;
+        const year = `${date.getFullYear()}`;
+        const month = (`0${date.getMonth() + 1}`).slice(-2); // 0-11 + 1;
+        const day = (`0${date.getDate()}`).slice(-2);// 1-31;
+        return `${year}-${month}-${day}`;
       })
       .reduce((acc: { [index: string]: number }, el: string) => {
         acc[el] = (acc[el] || 0) + 1;


### PR DESCRIPTION
Add 0 to 1-digit months and days to allow correct dates order on Statistics page.
Example: 2022-9-5 -> 2022-09-05.
![1-2-digit-days-months](https://user-images.githubusercontent.com/7703384/190510337-6ed445ce-b3ac-42bd-b85e-7b68249b8f6c.jpg)
